### PR TITLE
Add command line arguments to Jackett

### DIFF
--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -54,6 +54,9 @@
     <StartupObject>Jackett.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine">
+      <HintPath>..\packages\CommandLineParser.2.0.89-alpha\lib\net45\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="CsQuery">
       <HintPath>..\packages\CsQuery.1.3.4\lib\net40\CsQuery.dll</HintPath>
     </Reference>
@@ -121,6 +124,7 @@
     <Compile Include="Main.Designer.cs">
       <DependentUpon>Main.cs</DependentUpon>
     </Compile>
+    <Compile Include="Options.cs" />
     <Compile Include="ParseUtil.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Jackett/Options.cs
+++ b/src/Jackett/Options.cs
@@ -1,0 +1,50 @@
+﻿using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Jackett
+{
+    public class Options
+    {
+        public bool ListenSet = false;
+        private bool listenPublic;
+        private bool listenPrivate;
+
+        [Option('d', "directory", 
+            HelpText = "Configuration directory, any other command line arguments will override the configuration")]
+        public string Directory { get; set; }
+
+        [Option('p', "port", HelpText = "Port to use")]
+        public int Port { get; set; }
+
+        [Option('l', "listen_public", HelpText = "Listen publicly")]
+        public bool ListenPublic
+        {
+            get { return listenPublic; }
+            set
+            {
+                ListenSet = true; 
+                listenPublic = true;
+            }
+        }
+
+        [Option('L', "listen_private", HelpText = "Listen privately")]
+        public bool ListenPrivate
+        {
+            get{ return listenPrivate; }
+            set
+            {
+                ListenSet = true;
+                listenPrivate = true;
+            }
+        }
+
+        [Option(
+            HelpText = "Prints all messages to standard output.")]
+        public bool Verbose { get; set; }
+    }
+}

--- a/src/Jackett/Program.cs
+++ b/src/Jackett/Program.cs
@@ -1,4 +1,5 @@
-﻿using Jackett.Indexers;
+using Jackett.Indexers;
+using CommandLine;
 using Newtonsoft.Json.Linq;
 using NLog;
 using NLog.Config;

--- a/src/Jackett/Server.cs
+++ b/src/Jackett/Server.cs
@@ -25,12 +25,13 @@ namespace Jackett
         WebApi webApi;
 
 
-        public Server()
+        public Server(int port, bool listenPublic)
         {
             // Allow all SSL.. sucks I know but mono on linux is having problems without it..
             ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => true;
 
-            ReadServerSettingsFile();
+            Port = port;
+            ListenPublic = listenPublic;
             LoadApiKey();
 
             indexerManager = new IndexerManager();

--- a/src/Jackett/packages.config
+++ b/src/Jackett/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="2.0.89-alpha" targetFramework="net451" />
   <package id="CsQuery" version="1.3.4" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
   <package id="NLog" version="4.0.1" targetFramework="net451" />


### PR DESCRIPTION
it's always easier in Linux to have command line arguments.
So I added some : 
- `-d Directory` allows to choose the right directory (useful in docker or when user has no directory)
- `-p Port` allows to choose the port and write it in the config
- `-l` allows to listen publicly and write it in the config
- `-L` allows to listen private and write it in the config
- `--verbose` gives you more detail (currently one line but could be done to give DEBUG messages)
- `--help` gives help
