### PR TITLE
use correct name for bakabt.png

### DIFF
--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -345,7 +345,7 @@
     <Content Include="Content\logos\animebytes.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Content\logos\bakabt.png">
+    <Content Include="Content\logos\BakaBT.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Content\logos\bb.png">


### PR DESCRIPTION
older one was not using the correct case, which causes an error on unix (BakaBT.png is the correct not bakabt.png)
