### PR TITLE
Style changes

### DIFF
--- a/src/Jackett/Content/custom.css
+++ b/src/Jackett/Content/custom.css
@@ -24,11 +24,12 @@
     background-color: #f9f9f9;
     border-radius: 6px;
     box-shadow: 1px 1px 5px 2px #cdcdcd;
-    padding: 10px;
     width: 270px;
     display: inline-block;
     vertical-align: top;
     margin: 5px;
+    overflow: hidden;
+    position: relative;
 }
 
 #indexers {
@@ -58,12 +59,18 @@
 }
 
 .indexer-logo {
-    text-align: center;
     padding-bottom: 5px;
 }
 
+    .indexer-logo > .hidden-name {
+        position: absolute;
+        color: rgba(255, 255, 255, 0);
+        left: 0;
+    }
+
     .indexer-logo > img {
-        border: 1px solid #828282;
+        width: 100%;
+        border-bottom: 1px solid #FFF;
     }
 
 .indexer-name > h3 {

--- a/src/Jackett/Content/index.html
+++ b/src/Jackett/Content/index.html
@@ -146,7 +146,11 @@
 
     <script id="configured-indexer" type="text/x-handlebars-template">
         <div class="configured-indexer indexer card">
-            <div class="indexer-logo"><img alt="{{name}}" title="{{name}}" src="/logos/{{id}}.png" /></div>
+            <div class="indexer-logo">
+                <!-- Make section browser searchable -->
+                <span class="hidden-name">{{name}}</span>
+                <img alt="{{name}}" title="{{name}}" src="/logos/{{id}}.png" />
+            </div>
             <div class="indexer-buttons">
                 <button class="btn btn-primary btn-sm indexer-setup" data-id="{{id}}">
                     <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
@@ -176,7 +180,11 @@
     </script>
     <script id="unconfigured-indexer" type="text/x-handlebars-template">
         <div class="unconfigured-indexer card">
-            <div class="indexer-logo"><img alt="{{name}}" title="{{name}}" src="/logos/{{id}}.png" /></div>
+            <div class="indexer-logo">
+                <!-- Make section browser searchable -->
+                <span class="hidden-name">{{name}}</span>
+                <img alt="{{name}}" title="{{name}}" src="/logos/{{id}}.png" />
+            </div>
             <div class="indexer-buttons">
                 <a class="btn btn-info" target="_blank" href="{{site_link}}">Visit <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
                 <button class="indexer-setup btn btn-success" data-id="{{id}}">Setup <span class="glyphicon glyphicon-ok" aria-hidden="true"></span></button>


### PR DESCRIPTION
- Made indexers searchable in browser (Ctrl+f)
- Modified how logos are shown in cards (note: stretches the images): 

New:
![image](https://cloud.githubusercontent.com/assets/1748521/10248628/0741330e-6921-11e5-9119-0c5c08db1bee.png)
Old:
![image](https://cloud.githubusercontent.com/assets/1748521/10248691/6d9a626a-6921-11e5-968b-3f3062c4cb46.png)
