### PR TITLE
TorrentBytes.net - Added check to ensure we grabbed the correct table

### DIFF
--- a/src/Jackett/Indexers/TorrentBytes.cs
+++ b/src/Jackett/Indexers/TorrentBytes.cs
@@ -136,6 +136,11 @@ namespace Jackett.Indexers
                 CQ dom = results;
 
                 var rows = dom["#content table:eq(4) tr"];
+                // If we return 4 rows the ratio warning banner must be displayed, skip to next table.
+                if (rows.Length.Equals(4))
+                {
+                    rows = dom["#content table:eq(5) tr"];
+                }
                 foreach (var row in rows.Skip(1))
                 {
                     var release = new ReleaseInfo();


### PR DESCRIPTION
During configuration If a user's ratio is dangerously low the page displays an extra table with a warning banner.  This extra table throws off the jQuery selection.  Since the table does not have any identifiers to write a better selector, I just ensure that the amount of rows returned isn't 4, if it is we select the next table.
